### PR TITLE
Mbox fixes

### DIFF
--- a/lib/Email/Folder/Mbox.pm
+++ b/lib/Email/Folder/Mbox.pm
@@ -278,7 +278,6 @@ sub next_messageref {
         }
 
         if ($prev eq $/ && ($line =~ $self->_from_line_re)) {
-            $mail .= $prev;
             $last = $line;
             last;
         }
@@ -293,6 +292,7 @@ sub next_messageref {
         # unescape From_
         $prev =~ s/^>(>*From )/$1/ if $self->{unescape};
     }
+    $mail .= $prev;
     print "$count end of message line $.\n" if debug;
     $self->{from} = $last;
     return unless $mail;

--- a/lib/Email/Folder/Mbox.pm
+++ b/lib/Email/Folder/Mbox.pm
@@ -106,6 +106,10 @@ This returns the current filehandle position in the mbox.
 
 This returns the From_ line for next message. Call it before ->next_message.
 
+=item C<messageid>
+
+This returns the messageid of last read message. Call if after ->next_message.
+
 =back
 
 =cut
@@ -186,6 +190,8 @@ sub next_messageref {
 
     my $fh = $self->{_fh} || $self->_open_it;
     local $/ = $self->{eol};
+
+    $self->{messageid} = undef;
 
     my $mail = '';
     my $prev = '';
@@ -277,6 +283,10 @@ sub next_messageref {
             last;
         }
 
+        if ($inheaders && !defined $self->{messageid} && ($line =~ /^Message-Id:\s*(.+)/i)) {
+            $self->{messageid} = $1;
+        }
+
         $mail .= $prev;
         $prev = $line;
 
@@ -316,6 +326,11 @@ sub _from_line_re {
 sub tell {
     my $self = shift;
     return tell $self->{_fh};
+}
+
+sub messageid {
+    my $self = shift;
+    return $self->{messageid};
 }
 
 1;

--- a/lib/Email/Folder/Mbox.pm
+++ b/lib/Email/Folder/Mbox.pm
@@ -126,7 +126,7 @@ sub _open_it {
     unless ($file eq "FH" and $fh) {
         # sanity checking
         croak "$file does not exist" unless (-e $file);
-        croak "$file is not a file"  unless (-f $file);
+        croak "$file is a directory" if (-d $file);
 
         local $/ = $self->{eol};
         $fh = $self->_get_fh($file);

--- a/lib/Email/Folder/Mbox.pm
+++ b/lib/Email/Folder/Mbox.pm
@@ -90,11 +90,11 @@ variant, so default value is false.
 Seek to an offset when opening the mbox.  When used in combination with
 ->tell you may be able to resume reading, with a trailing wind.
 
-=item <next_message>
+=item C<next_message>
 
 This returns next message as string
 
-=item <next_messageref>
+=item C<next_messageref>
 
 This returns next message as ref to string
 


### PR DESCRIPTION
This pull request fix parsing emails (last line of mboxo/mboxrd variant is ignored), fix documentation format, delete useless check for regular file (Mbox module already supports non-seekable files) and add function messageid() which returns Message-Id.